### PR TITLE
Use organization URL and fix linting URL in README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 🍰 Shortcake
 ############
 
-.. image:: https://img.shields.io/github/workflow/status/BryceBeagle/shortcake/tests/main?label=tests&style=for-the-badge
-  :target: https://github.com/BryceBeagle/shortcake/actions/workflows/tests.yml
-.. image:: https://img.shields.io/github/workflow/status/BryceBeagle/shortcake/tests/main?label=linting&style=for-the-badge
-  :target: https://github.com/BryceBeagle/shortcake/actions/workflows/linting.yml
+.. image:: https://img.shields.io/github/workflow/status/shortcake-dev/shortcake/tests/main?label=tests&style=for-the-badge
+  :target: https://github.com/shortcake-dev/shortcake/actions/workflows/tests.yml
+.. image:: https://img.shields.io/github/workflow/status/shortcake-dev/shortcake/linting/main?label=linting&style=for-the-badge
+  :target: https://github.com/shortcake-dev/shortcake/actions/workflows/linting.yml
 
 In-progress recipe website that will use Strawberry_ for its backend API.
 


### PR DESCRIPTION
Resolves #73 
Resolves #74 