### PR TITLE
Rename deploy secret to get around new secret naming rules

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -24,7 +24,7 @@ on:
         required: true
       dockerhub_token:
         required: true
-      github_token:
+      gh_token:
         required: true
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ inputs.github_orgname }}
-          password: ${{ secrets.github_token }}
+          password: ${{ secrets.gh_token }}
 
       - name: "Build and push"
         uses: docker/build-push-action@v2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -7,7 +7,6 @@ on:
 jobs:
 
   dev-docker-deploy:
-    # yamllint disable-line rule:line-length
     uses: shortcake-dev/shortcake/.github/workflows/deploy-docker.yml@main
     with:
       image_name: "shortcake"

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -7,7 +7,8 @@ on:
 jobs:
 
   dev-docker-deploy:
-    uses: shortcake-dev/shortcake/.github/workflows/deploy-docker.yml@main
+    # yamllint disable-line rule:line-length
+    uses: shortcake-dev/shortcake/.github/workflows/deploy-docker.yml@034e63df802bed21fd1da45f6741f12b43fc6030
     with:
       image_name: "shortcake"
       tag: "dev-pr${{ github.event.number }}"

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -8,7 +8,7 @@ jobs:
 
   dev-docker-deploy:
     # yamllint disable-line rule:line-length
-    uses: shortcake-dev/shortcake/.github/workflows/deploy-docker.yml@034e63df802bed21fd1da45f6741f12b43fc6030
+    uses: shortcake-dev/shortcake/.github/workflows/deploy-docker.yml@main
     with:
       image_name: "shortcake"
       tag: "dev-pr${{ github.event.number }}"

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -19,4 +19,4 @@ jobs:
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves #90 